### PR TITLE
It is totally valid (and in my opinion, semantically better) to use row-...

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -420,7 +420,7 @@
 		    tdWidths.push($(this).width());
 		});
 
-		firstTdChildrenSelector = 'tbody tr td:not(:nth-child(n+' + (settings.fixedColumns + 1) + '))';
+		firstTdChildrenSelector = 'tbody tr td:not(:nth-child(n+' + (settings.fixedColumns + 1) + '))'+ ',tbody tr td:not(:nth-child(n+' + (settings.fixedColumns + 1) + '))';
 		$firstTdChildren = $fixedBody.find(firstTdChildrenSelector)
 		    .each(function(index) {
 			helpers._fixHeightWithCss($(this), tableProps);
@@ -564,7 +564,7 @@
                     tableProp.tfoot[index] = $(this).width() + tableProp.border;
                 });
                 
-                $obj.find('tbody tr:first-child td').each(function(index) {
+                $obj.find('tbody tr:first-child td+th').each(function(index) {
                     tableProp.tbody[index] = $(this).width() + tableProp.border;
                 });
 


### PR DESCRIPTION
...based th elements (usually with a scope attribute of "row"), to differentiate between a row header and actual row data.  This commit fixes the selectors for the fixedColumns attribute so that both td and th elements in the tbody to be fixed.  I think a more long-term solution would be to enforce the use of row-level th elements and only set those columns to be fixed.  But for now, this accounts for both.  Great project. Hope this helps.
