### PR TITLE
Removed a comma beacuse IE7 doesn't like them in front of }

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -500,7 +500,7 @@
 		    footwidth = $tfoot.find('table').innerWidth();
 		    $tfoot.css({
 			'top': settings.scrollbarOffset,
-			'width': footwidth,
+			'width': footwidth
 		    });
 		}
 	    },


### PR DESCRIPTION
I removed the comma in jquery.fixedheadertable.js in these lines:

```
        'width': fixedColumnWidth,
    })
```

because IE7 didn't really like it. 
