### PR TITLE
preventing 'apply' method call on undefined obj

### DIFF
--- a/lib/jquery.mousewheel.js
+++ b/lib/jquery.mousewheel.js
@@ -84,7 +84,9 @@ function handler(event) {
     // Add event and delta to the front of the arguments
     args.unshift(event, delta, deltaX, deltaY);
     
-    return $.event.handle.apply(this, args);
+    if ($.event.handle) {
+        return $.event.handle.apply(this, args);
+    }
 }
 
 })(jQuery);


### PR DESCRIPTION
This fixes an Error that is thrown when I scroll the page till fixed column is under the mouse pointer.

``` javascript
Uncaught TypeError: Cannot call method 'apply' of undefined
```
