### PR TITLE
Ignore colspaned columns for table properties calculations

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -567,15 +567,15 @@
 
         tableProp.border = ($obj.find('th:first-child').outerWidth() - $obj.find('th:first-child').innerWidth()) / borderCollapse;
 
-        $obj.find('thead tr:first-child > *').each(function(index) {
+        $obj.find('thead tr:first-child > *:not([colspan])').each(function(index) {
           tableProp.thead[index] = $(this).width() + tableProp.border;
         });
 
-        $obj.find('tfoot tr:first-child > *').each(function(index) {
+        $obj.find('tfoot tr:first-child > *:not([colspan])').each(function(index) {
           tableProp.tfoot[index] = $(this).width() + tableProp.border;
         });
 
-        $obj.find('tbody tr:first-child > *').each(function(index) {
+        $obj.find('tbody tr:first-child > *:not([colspan])').each(function(index) {
           tableProp.tbody[index] = $(this).width() + tableProp.border;
         });
 


### PR DESCRIPTION
If the first td/th has a colspan the column calculations go crazy... :)
