### PR TITLE
Script inserts missing thead and may move first tr

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -64,7 +64,7 @@
       setup: function () {
         var $self       = $(this),
             self        = this,
-            $thead      = $self.find('thead'),
+            $thead      = helpers._getTHead($self),
             $tfoot      = $self.find('tfoot'),
             tfootHeight = 0,
             $wrapper,
@@ -308,7 +308,7 @@
       _isTable: function($obj) {
         var $self = $obj,
             hasTable = $self.is('table'),
-            hasThead = $self.find('thead').length > 0,
+	        hasThead = ($self.find('thead').length > 0 || $self.find('tr').first().length > 0),
             hasTbody = $self.find('tbody').length > 0;
 
         if (hasTable && hasThead && hasTbody) {
@@ -318,7 +318,17 @@
         return false;
 
       },
-
+      _getTHead: function($obj) {
+	    var $self = $obj;
+	    if ($self.find('thead').length > 0) {
+		    return $self.find('thead');
+	    } else if ($self.find('tr').first().length > 0) {
+		    $self.prepend('<thead></thead>');
+		    $self.find('tr').first().detach().appendTo($self.find('thead'));
+		    return $self.find('thead');
+	    }
+	    return self;
+      },
       /*
        * return void
        * bind scroll event


### PR DESCRIPTION
This script works just the same as before by default but now if there is
no thead element, a thead is inserted and the first row found is moved into the
thead element. This allows the script to work in places where a proper
thead may not be generated.
