### PR TITLE
group reset box-sizing to content-box

### DIFF
--- a/css/defaultTheme.css
+++ b/css/defaultTheme.css
@@ -37,6 +37,7 @@
 	font-size: 100%;
 	font: inherit;
 	vertical-align: top;
+	box-sizing: content-box;
 	}
 
 .fht-table {


### PR DESCRIPTION
I've came across this issue when trying to use fixedColumns: {int}. There was an issue with the width of the fixed columns where it would show every column like a duplicate behind the fixed columns when using padding on the cells. After some investigation I noticed Foundation CSS framework was adding a box-sizing: border-box to all elements, including table cells. 

I believe this reset will help others in similar situation in the future, where the table already has styles.