### PR TITLE
Fix exception when settings.width is a number

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -78,7 +78,7 @@
         settings.scrollbarOffset = helpers._getScrollbarWidth();
         settings.themeClassName = settings.themeClass;
 
-        if (settings.width.search('%') > -1) {
+        if (settings.width.search && settings.width.search('%') > -1) {
             widthMinusScrollbar = $self.parent().width() - settings.scrollbarOffset;
         } else {
             widthMinusScrollbar = settings.width - settings.scrollbarOffset;


### PR DESCRIPTION
The API on http://www.fixedheadertable.com/ shows settings.width can be a number. I have confirmed that settings.height can be a number. However, the code assumes that settings.width is a string and does not work when it is a number. This fixes that issue.
