### PR TITLE
header width and  table height issue

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -131,6 +131,10 @@
             $divHead = $('<div class="fht-thead"><table class="fht-table"></table></div>').prependTo($wrapper);
           }
 
+          $divHead.css({
+            'width': widthMinusScrollbar
+          });
+
           $divHead.find('table.fht-table')
             .addClass(settings.originalTable.attr('class'))
             .attr('style', settings.originalTable.attr('style'));
@@ -160,7 +164,7 @@
           tfootHeight = $tfoot.outerHeight(true);
         }
 
-        var tbodyHeight = $wrapper.height() - $thead.outerHeight(true) - tfootHeight - tableProps.border;
+        var tbodyHeight = Math.min.apply(null, [$wrapper.height(), $(window).height()]) - $thead.outerHeight(true) - tfootHeight - tableProps.border;
 
         $divBody.css({
           'height': tbodyHeight


### PR DESCRIPTION
1. The table height is not correct when table is larger than the window size.  As a result, the scroll bar is not showing.

2. The width of the table header doesn't consider the scroll bar space.  As a result, the table header doesn't align right with the body.  I believe this only happens when the table is taking 100% width of the window size.