### PR TITLE
Fix destroy method creating two tfoots

### DIFF
--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -286,7 +286,7 @@
 
         $self.insertBefore($wrapper)
           .removeAttr('style')
-          .append($wrapper.find('tfoot'))
+          .append($wrapper.find('.fht-fixed-body tfoot'))
           .removeClass('fht-table fht-table-init')
           .find('.fht-cell')
           .remove();


### PR DESCRIPTION
When destroy is called on table with tfoot previously created, tfoot is copied from fixed column and body section both.