### PR TITLE
Adding rtl for fixed header table

### DIFF
--- a/css/defaultTheme.css
+++ b/css/defaultTheme.css
@@ -83,7 +83,15 @@
 	    left: 0;
 	    position: absolute;
 	    }
-	    
+	
+	.fht-table-wrapper .fht-fixed-column[data-rtl],
+	.fht-table-wrapper .fht-fixed-body[data-rtl] {
+		/* position */
+		top: 0;
+		right: 0;
+		position: absolute;
+	}
+	
 	.fht-table-wrapper .fht-fixed-column {
 	    /* position */
 	    z-index: 1;

--- a/jquery.fixedheadertable.js
+++ b/jquery.fixedheadertable.js
@@ -77,6 +77,7 @@
         settings.includePadding = helpers._isPaddingIncludedWithWidth();
         settings.scrollbarOffset = helpers._getScrollbarWidth();
         settings.themeClassName = settings.themeClass;
+        settings.directionRtl = $("body").css("direction") === "rtl";
 
         if (settings.width.search && settings.width.search('%') > -1) {
             widthMinusScrollbar = $self.parent().width() - settings.scrollbarOffset;
@@ -102,8 +103,13 @@
 
         if (settings.fixedColumns > 0 && $wrapper.find('.fht-fixed-column').length == 0) {
           $self.wrap('<div class="fht-fixed-body"></div>');
+            
+          var rtl = "";
+          if (settings.directionRtl) {
+              rtl = "data-rtl";
+          }
 
-          $('<div class="fht-fixed-column"></div>').prependTo($wrapper);
+          $('<div class="fht-fixed-column"' + rtl + '></div>').prependTo($wrapper);
 
           $fixedBody    = $wrapper.find('.fht-fixed-body');
         }
@@ -337,18 +343,32 @@
               .css({
                   'margin-top': -$self.scrollTop()
               });
-          }
+            }
 
-          $thead.find('table')
-            .css({
-              'margin-left': -this.scrollLeft
-            });
+          if (settings.directionRtl) {
+              $thead.find('table')
+                  .css({
+                      'margin-right': -(this.scrollWidth - this.clientWidth - this.scrollLeft)
+                  });
 
-          if (settings.footer || settings.cloneHeadToFoot) {
-            $tfoot.find('table')
-              .css({
-                'margin-left': -this.scrollLeft
-              });
+              if (settings.footer || settings.cloneHeadToFoot) {
+                  $tfoot.find('table')
+                      .css({
+                          'margin-right': -(this.scrollWidth - this.clientWidth - this.scrollLeft)
+                      });
+              }
+          } else {
+              $thead.find('table')
+                  .css({
+                      'margin-left': -this.scrollLeft
+                  });
+
+              if (settings.footer || settings.cloneHeadToFoot) {
+                  $tfoot.find('table')
+                      .css({
+                          'margin-left': -this.scrollLeft
+                      });
+              }
           }
         });
       },


### PR DESCRIPTION
When UI is right-to-left, the library has to fix header of the table in the opposite side. The first column has to be in right side and also the scroll has to change.

For that, I add a setting to know if the direction of the body is 'rtl'. Then you add 'data-rtl' with 'fht-fixed-column' class.

With the settings you can set a correct functionality of scroll and using 'data-rtl' you can apply the correct css style.

